### PR TITLE
[chart] Allow use of private registry

### DIFF
--- a/chart/acmeair-flightservice-java/templates/deployment.yaml
+++ b/chart/acmeair-flightservice-java/templates/deployment.yaml
@@ -16,9 +16,16 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9080"
     spec:
+{{ if .Values.privateRegistry.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.privateRegistry.imagePullSecrets }}
       containers:
-      - name: "{{  .Chart.Name  }}"
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      - image: "{{ .Values.privateRegistry.repository }}/{{ .Values.image.imageName }}:{{ .Values.image.tag }}"
+{{ else }}
+      containers:
+      - image: "{{ .Values.image.imageName }}:{{ .Values.image.tag }}"
+{{ end }}
+        name: "{{  .Chart.Name  }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ if .Values.istio.enabled }}
 {{ else }}

--- a/chart/acmeair-flightservice-java/values.yaml
+++ b/chart/acmeair-flightservice-java/values.yaml
@@ -3,13 +3,17 @@
 replicaCount: 1
 revisionHistoryLimit: 1
 image:
-  repository: acmeair-flightservice-java
+  imageName: acmeair-flightservice-java
   tag: latest
   pullPolicy: IfNotPresent
   resources:
     requests:
       cpu: 200m
       memory: 300Mi
+privateRegistry:
+  enabled: false
+  repository:
+  imagePullSecrets:
 service:
   name: acmeair-flight-service
   type: ClusterIP


### PR DESCRIPTION
- This change will allow users to configure private registry for images
- Can be configured/overriden from the command line with --set

For example:
`helm template chart/acmeair-flightservice-java --output-dir test-template --set privateRegistry.enabled=true,privateRegistry.repository=exampleregistry.azurecr.io/default,privateRegistry.imagePullSecrets=acr-auth`

@jdmcclur I'm waiting on your feedback of this PR, if you are interested in this change I can propagate to your other BluePerf/ repos.

With this change users can deploy the images to any registry of there liking plus you can still have the previous behavior by default.

Thanks